### PR TITLE
revert(nvim): add `CTRL+i` to show signature help popup

### DIFF
--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -115,8 +115,6 @@ return {
 
           map('<leader>rn', vim.lsp.buf.rename, '[R]e[n]ame')
           map('<leader>ca', vim.lsp.buf.code_action, '[C]ode [A]ction', { 'n', 'x' })
-
-          map('<C-i>', vim.lsp.buf.signature_help, 'Show signature help', { 'i', 'n' })
         end
       })
 


### PR DESCRIPTION
This reverts commit fed619868ae1bb4a43d0dcdc01011d491102a5ac due to issue with `tab` key mapping that trigger `signature_help` instead of actual `tab` function.