### PR TITLE
feat(nvim): make php debugger to work

### DIFF
--- a/nvim/lua/plugins/debug.lua
+++ b/nvim/lua/plugins/debug.lua
@@ -26,6 +26,19 @@ return {
       local dap = require('dap')
       local dapui = require('dapui')
 
+      ---Retrieve mason package install path
+      ---@param package_name string
+      ---@param path string
+      ---@return string
+      local function get_mason_pkg_path (package_name, path)
+        local util = require('lspconfig.util')
+
+        return util.path.join(
+          require('mason-registry').get_package(package_name):get_install_path(),
+          path
+        )
+      end
+
       require('mason-nvim-dap').setup({
         automatic_installation = true,
         ensure_installed = {
@@ -34,6 +47,27 @@ return {
           'php-debug-adapter',
           'js-debug-adapter',
           'node-debug2-adapter',
+        },
+        handlers = {
+          -- all sources with no handler get passed here
+          -- see https://github.com/jay-babu/mason-nvim-dap.nvim?tab=readme-ov-file#advanced-customization
+          function (config)
+            require('mason-nvim-dap').default_setup(config)
+          end,
+
+          -- https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#php
+          ---@param config table
+          php = function (config)
+            config.adapters = {
+              type = 'executable',
+              command = 'node',
+              args = {
+                get_mason_pkg_path('php-debug-adapter', 'extension/out/phpDebug.js'),
+              }
+            }
+
+            require('mason-nvim-dap').default_setup(config)
+          end
         }
       })
 


### PR DESCRIPTION
### Links
- [Debug Adapter Installation Wiki](https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation)
- #15 

It took me quite some times to figure out the way to configure it properly, to the point that I noticed that DAP (Debug Adapter Protocol) is made by Microsoft. So that's why the `nvim-dap` wiki is mostly refering to vscode debugger extension.

Moreover I could even use my `.vscode/launch.json` config from one of my existing project. And the workflow is pretty much the same.

- Open the editor (VS Code or Neovim), activate debugger using `<F5>` to make sure that the debugger client is running.
- Start the dev server with `XDEBUG_SESSION=<your-editor>` environment,

  ```sh
  XDEBUG_SESSION=vscode ./artisan serve --host 0.0.0.0
  ```
  To notify the `php-cli` that it should run with xdebug in debug mode. 

https://github.com/user-attachments/assets/29ae221f-6c9b-4cbd-b95d-2475322a79eb

https://github.com/user-attachments/assets/790612a8-0f70-469e-876a-74c05b2c11ab

### Summary

- Anything you know about debugging in VS Code, just bring them in to Neovim
- The rest is just a matter of understanding the `dapui` it self