### PR TITLE
feat(nvim): add `neotest` to integrate testing functionality

### DIFF
--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -1,4 +1,5 @@
 {
+  "FixCursorHold.nvim": { "branch": "master", "commit": "1900f89dc17c603eec29960f57c00bd9ae696495" },
   "LuaSnip": { "branch": "master", "commit": "e808bee352d1a6fcf902ca1a71cee76e60e24071" },
   "ayu": { "branch": "master", "commit": "2839c88cd297a069e93df1aab542c087e8f6e8c0" },
   "blade-nav.nvim": { "branch": "main", "commit": "1c239f36829a3c004586ae6bfbf7f2eb7a41f6d1" },
@@ -22,6 +23,10 @@
   "mini.pairs": { "branch": "main", "commit": "e543c760edc5e746e5b6cbd02c066c17ead3ef16" },
   "mini.surround": { "branch": "main", "commit": "0e67c4bc147f2a15cee94e7c94dcc0e115b9f55e" },
   "neo-tree.nvim": { "branch": "v3.x", "commit": "29f7c215332ba95e470811c380ddbce2cebe2af4" },
+  "neotest": { "branch": "master", "commit": "6d6ad113f56edc7c3f2a77a0836ea8c1b955ebea" },
+  "neotest-pest": { "branch": "main", "commit": "b665a4881c706eea476fcaf79a21996e9b65514d" },
+  "neotest-phpunit": { "branch": "main", "commit": "baae8dfa0a3aaacd9f0bb6845d6348f5bcdc48bb" },
+  "neotest-vitest": { "branch": "main", "commit": "9e30dca989a2287cf3fde86b3e138ea7fa4de935" },
   "noice.nvim": { "branch": "main", "commit": "448bb9c524a7601035449210838e374a30153172" },
   "nui.nvim": { "branch": "main", "commit": "b58e2bfda5cea347c9d58b7f11cf3012c7b3953f" },
   "nvim-cmp": { "branch": "main", "commit": "ae644feb7b67bf1ce4260c231d1d4300b19c6f30" },

--- a/nvim/lua/plugins/tests.lua
+++ b/nvim/lua/plugins/tests.lua
@@ -1,0 +1,58 @@
+return {
+  {
+    'antoinemadec/FixCursorHold.nvim',
+    lazy = true,
+  },
+
+  {
+    'V13Axel/neotest-pest',
+    lazy = true,
+  },
+
+  {
+    'olimorris/neotest-phpunit',
+    lazy = true,
+  },
+
+  {
+    'marilari88/neotest-vitest',
+    lazy = true,
+  },
+
+  {
+    'nvim-neotest/neotest',
+    dependencies = {
+      { 'nvim-neotest/nvim-nio' },
+      { 'nvim-lua/plenary.nvim' },
+      { 'antoinemadec/FixCursorHold.nvim' },
+      { 'nvim-treesitter/nvim-treesitter' },
+      { 'V13Axel/neotest-pest' },
+      { 'olimorris/neotest-phpunit' },
+      { 'marilari88/neotest-vitest' },
+    },
+    opts = function()
+      ---@type neotest.Config
+      return {
+        discovery = {
+          enabled = false,
+        },
+        adapters = {
+          require('neotest-vitest'),
+          require('neotest-pest'),
+          require('neotest-phpunit')({
+            root_ignore_files = { 'tests/Pest.php' },
+          }),
+        },
+      }
+    end,
+    keys = {
+      { '<leader>tr', function() require('neotest').run.run() end, desc = '[T]est [R]un' },
+      { '<leader>tx', function() require('neotest').run.stop() end, desc = '[T]est stop' },
+      { '<leader>td', function() require('neotest').run.run({ strategy = 'dap' }) end, desc = '[T]est run with [D]AP' },
+      { '<leader>tf', function() require('neotest').run.run(vim.fn.expand('%')) end, desc = '[T]est [F]ile' },
+      { '<leader>ts', function() require('neotest').run.run({ suite = true }) end, desc = '[T]est [S]uite' },
+      { '<leader>to', function() require('neotest').output() end, desc = '[T]est [O]utput' },
+      { '<leader>tS', function() require('neotest').summary.toggle() end, desc = 'Toggle [T]est [S]ummary' },
+    },
+  },
+}


### PR DESCRIPTION
### Keymap

- `<leader>tr` : Run nearest test
- `<leader>tx` : Stop test
- `<leader>td` : Run test with DAP
- `<leader>tf` : Run test file
- `<leader>ts` : Run test suite
- `<leader>to` : Show test output
- `<leader>tS` : Toggle tests summary

### Adapters

- [`phpunit`](https://github.com/olimorris/neotest-phpunit)
- [`pest`](https://github.com/V13Axel/neotest-pest)
- [`vitest`](https://github.com/marilari88/neotest-vitest)