### PR TITLE
feat: try `ghostty`

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,0 +1,8 @@
+font-family = "FiraCode Nerd Font"
+font-size = 16
+
+background-opacity = 0.8
+background-blur-radius = 10
+
+command = /opt/homebrew/bin/tmux
+window-step-resize = true


### PR DESCRIPTION
Been waiting this for quite sometimes and it's time to try [`ghostty`](https://ghostty.org) out. Can it replace `iTerm2` on my machine?