### PR TITLE
feat(asdf): workaround with `asdf` after being updated to `0.16`

### DIFF
--- a/.exports
+++ b/.exports
@@ -32,11 +32,6 @@ if [[ -x /opt/homebrew/bin/brew ]]; then
        PATH="`brew --prefix ruby`/bin:$PATH"
        PATH="`gem env home`/bin:$PATH"
     fi
-
-    # ==============================================================================
-    # ASDF-VM
-    # ==============================================================================
-    [[ -f "`brew --prefix asdf`/libexec/asdf.sh" ]] && source "`brew --prefix asdf`/libexec/asdf.sh"
 fi
 
 # ==============================================================================
@@ -61,11 +56,26 @@ if [[ -d "$HOME/.sdkman" ]]; then
 fi
 
 # ==============================================================================
-# Rust Cargo
+# Rust Cargo | https://crates.io/
 # ==============================================================================
 if [[ -d "$HOME/.cargo" ]]; then
     [[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
     [[ -d "$HOME/.cargo/bin" ]] && PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+# ==============================================================================
+# ASDF-VM | https://asdf-vm.com
+# ==============================================================================
+if command -v asdf >/dev/null 2>&1 && [[ -d "$HOME/.asdf" ]]; then
+    export ASDF_DATA_DIR="$HOME/.asdf"
+    PATH="$ASDF_DATA_DIR/shims:$PATH"
+
+    if [[ ! -d "$ASDF_DATA_DIR/completions" ]]; then
+        mkdir -p $ASDF_DATA_DIR/completions
+        asdf completion zsh > "$ASDF_DATA_DIR/completions/_asdf"
+    fi
+
+    FPATH="$ASDF_DATA_DIR/completions:$FPATH"
 fi
 
 # ==============================================================================


### PR DESCRIPTION
After update `asdf` to the latest version via `brew` I realized that there's something missing. Starts from :

- `HOME: unbound variable`
![Screenshot 2025-02-08 at 14 28 36](https://github.com/user-attachments/assets/a630f765-cfef-487a-a884-c6297f7aa810)
- The `asdf local` command is not working apparently
![Screenshot 2025-02-08 at 14 29 42](https://github.com/user-attachments/assets/698b5f2c-d0c7-4922-8e72-e30c704564fb)
- The `asdf list-all` command also not working
![Screenshot 2025-02-08 at 14 30 55](https://github.com/user-attachments/assets/cc853ecf-f5e6-44a5-93e7-64808fbfbaae)
- Up to the point that I couldn't list all available `nodejs`
![Screenshot 2025-02-08 at 14 31 23](https://github.com/user-attachments/assets/c8970ae6-bd53-4675-b764-e35d161435d6)

There's must be some breaking changes happening here. And sure enough, they're [rewriting](https://github.com/asdf-vm/asdf/releases/tag/v0.16.0) the damn thing.

Please consult to the official [upgrade guide](https://asdf-vm.com/guide/upgrading-to-v0-16.html) for more details
